### PR TITLE
Add basic Node tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "description": "Zodiom is a mesmerizing 3D cosmic simulator that lets you explore the solar system across space and time. Witness planetary alignments, travel to any date in history or the future, and toggle between photorealistic and mystical modes infused with sacred geometry and celestial symbolism.  Built for stargazers, seekers, and space nerds alike.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test",
     "build": "browserify src/main.js -p esmify -o public/bundle.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs",
+  "type": "module",
   "dependencies": {
     "astronomy-bundle": "^7.7.7",
     "three": "^0.177.0"

--- a/src/timeUtils.js
+++ b/src/timeUtils.js
@@ -1,4 +1,4 @@
-import {createTimeOfInterest} from 'astronomy-bundle/time';
+import {createTimeOfInterest} from 'astronomy-bundle/time/index.js';
 
 export function parseDateTime(value) {
   if (!value) {

--- a/test/timeUtils.test.js
+++ b/test/timeUtils.test.js
@@ -1,0 +1,22 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseDateTime } from '../src/timeUtils.js';
+
+function nearlyEqual(a, b, tolMs = 1000) {
+  return Math.abs(a - b) <= tolMs;
+}
+
+describe('parseDateTime', () => {
+  it('parses ISO date strings into TimeOfInterest objects', () => {
+    const toi = parseDateTime('2020-01-02T03:04:05Z');
+    assert.equal(toi.getDate().toISOString(), '2020-01-02T03:04:05.000Z');
+  });
+
+  it('returns current time when value is empty', () => {
+    const before = Date.now();
+    const toi = parseDateTime('');
+    const after = Date.now();
+    const t = toi.getDate().getTime();
+    assert.ok(nearlyEqual(t, before) || (t > before && t <= after));
+  });
+});


### PR DESCRIPTION
## Summary
- switch project to ESM modules
- adjust `parseDateTime` import for Node compatibility
- add Node.js test runner configuration
- write tests for `parseDateTime`

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68543dfcaa1483249080af2ca4e6b5ac