### PR TITLE
Fix createEarth import

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -5,13 +5,13 @@ import {createPlanetMeshes, updatePositions} from './planets.js';
 import {
   createMercury,
   createVenus,
-  createEarth,
   createMars,
   createJupiter,
   createSaturn,
   createUranus,
   createNeptune
 } from "astronomy-bundle/planets";
+import { createEarth } from "astronomy-bundle/earth";
 import {createSun as createSunSolo} from "astronomy-bundle/sun";
 const container = document.body;
 const {scene, camera, renderer, controls, light} = setupScene(container);

--- a/src/planets.js
+++ b/src/planets.js
@@ -3,13 +3,13 @@ import {createSun} from 'astronomy-bundle/sun';
 import {
   createMercury,
   createVenus,
-  createEarth,
   createMars,
   createJupiter,
   createSaturn,
   createUranus,
   createNeptune
 } from 'astronomy-bundle/planets';
+import { createEarth } from 'astronomy-bundle/earth';
 
 const SCALE = 5; // scale factor for visualization
 


### PR DESCRIPTION
## Summary
- import createEarth from the correct astronomy-bundle module
- ensure bundling uses the Earth creation helper

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6854ed7d19dc832486282e6b7d7749b3