### PR TITLE
Add planet labels and UI controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Zodiom is an in-browser 3D cosmic simulator built with Three.js and Astronomy Bu
 - Optional light mode for the UI
 - Orbit controls to freely navigate the scene
 - Animated timeline for smooth time travel
+- Planet labels with optional toggle
+- Toggle visibility of planetary orbits
+- Adjustable timeline speed
+- Reset camera position with one click
 
 ## Getting Started
 

--- a/public/index.html
+++ b/public/index.html
@@ -16,6 +16,11 @@
     body.light #ui { background: rgba(255,255,255,0.8); }
     canvas { display: block; }
     label { margin-right: 8px; }
+    .label {
+      font-size: 12px;
+      pointer-events: none;
+      text-shadow: 0 0 5px #000;
+    }
   </style>
 </head>
 <body>
@@ -32,7 +37,20 @@
       Light Mode
       <input type="checkbox" id="lightToggle" />
     </label>
+    <label>
+      Show Labels
+      <input type="checkbox" id="labelToggle" checked />
+    </label>
+    <label>
+      Show Orbits
+      <input type="checkbox" id="orbitToggle" checked />
+    </label>
+    <label>
+      Speed
+      <input type="range" id="speedRange" min="0.1" max="5" step="0.1" value="1" />
+    </label>
     <button id="playTimeline">Play Timeline</button>
+    <button id="resetCamera">Reset Camera</button>
   </div>
   <script src="bundle.js"></script>
 </body>

--- a/src/setupScene.js
+++ b/src/setupScene.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import {OrbitControls} from 'three/examples/jsm/controls/OrbitControls.js';
+import {CSS2DRenderer} from 'three/examples/jsm/renderers/CSS2DRenderer.js';
 
 export function setupScene(container) {
   const scene = new THREE.Scene();
@@ -11,6 +12,12 @@ export function setupScene(container) {
   const renderer = new THREE.WebGLRenderer({antialias: true});
   renderer.setSize(window.innerWidth, window.innerHeight);
   container.appendChild(renderer.domElement);
+
+  const labelRenderer = new CSS2DRenderer();
+  labelRenderer.setSize(window.innerWidth, window.innerHeight);
+  labelRenderer.domElement.style.position = 'absolute';
+  labelRenderer.domElement.style.top = '0px';
+  container.appendChild(labelRenderer.domElement);
 
   const controls = new OrbitControls(camera, renderer.domElement);
   controls.enableDamping = true;
@@ -25,7 +32,8 @@ export function setupScene(container) {
     camera.aspect = window.innerWidth / window.innerHeight;
     camera.updateProjectionMatrix();
     renderer.setSize(window.innerWidth, window.innerHeight);
+    labelRenderer.setSize(window.innerWidth, window.innerHeight);
   });
 
-  return {scene, camera, renderer, controls, light};
+  return {scene, camera, renderer, controls, light, labelRenderer};
 }


### PR DESCRIPTION
## Summary
- display planet labels using CSS2DRenderer
- add UI controls for labels, orbits, speed, and camera reset
- wire up new controls in main script
- document new options in README

## Testing
- `npm install`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854f11f8d688324aa33d94277b6e191