### PR TITLE
Ensure build step runs before serving

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "node --test",
     "build": "browserify src/main.js -p esmify -o public/bundle.js",
+    "preserve": "npm run build",
     "serve": "node server.js"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- trigger the `build` script automatically whenever `npm run serve` is executed so the site always has an up-to-date bundle

## Testing
- `npm test`
- `npm run serve` *(fails: EADDRINUSE if port already in use; otherwise starts server)*

------
https://chatgpt.com/codex/tasks/task_e_6855767f64308324a61a37ea32291b0e