### PR TITLE
Fix start script to build bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ npm install
 npm run build
 ```
 
-Start the development server and open `http://localhost:3000` in your browser:
+Start the development server (the bundle will be built automatically) and open `http://localhost:3000` in your browser:
 
 ```bash
-npm run serve
+npm start
 ```
 
 ## Development

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "test": "node --test",
     "build": "browserify src/main.js -p esmify -o public/bundle.js",
     "preserve": "npm run build",
-    "serve": "node server.js"
+    "serve": "node server.js",
+    "prestart": "npm run build",
+    "start": "node server.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- build bundle automatically when using `npm start`
- document the new start command

## Testing
- `npm test`
- `npm run build`
- `npm start` (manual server run)

------
https://chatgpt.com/codex/tasks/task_e_685578099e7083249fbae8b77eea2530