### PR TITLE
Fix pointer events blocking UI

### DIFF
--- a/src/setupScene.js
+++ b/src/setupScene.js
@@ -17,6 +17,8 @@ export function setupScene(container) {
   labelRenderer.setSize(window.innerWidth, window.innerHeight);
   labelRenderer.domElement.style.position = 'absolute';
   labelRenderer.domElement.style.top = '0px';
+  // Allow mouse interaction with underlying UI elements and the canvas
+  labelRenderer.domElement.style.pointerEvents = 'none';
   container.appendChild(labelRenderer.domElement);
 
   const controls = new OrbitControls(camera, renderer.domElement);


### PR DESCRIPTION
## Summary
- allow mouse interaction with the canvas and UI by disabling pointer events on the label renderer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68558f5fb3ec8324a85ee285f9b556f1