### PR TITLE
Improve README for esbuild install

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ npm install
 npm run build
 ```
 
+If `npm start` or `npm run serve` is run before installing dependencies, you'll
+see an `esbuild: not found` error. Always run `npm install` first to download
+all required packages.
+
 Start the development server (the bundle will be built automatically) and open `http://localhost:3000` in your browser:
 
 ```bash


### PR DESCRIPTION
## Summary
- clarify in README that `npm install` is required before running the server

## Testing
- `npm test`
- `npm run serve`

------
https://chatgpt.com/codex/tasks/task_e_6855a8129c488324bf137c7deee3724e