### PR TITLE
Fix initialization race for React UI

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -25,6 +25,13 @@ if (uiRoot) {
   root.render(<UI />);
 }
 
+// Wait for the React UI to finish mounting before initializing the scene
+if (document.getElementById('datetime')) {
+  requestAnimationFrame(init);
+} else {
+  window.addEventListener('ui-ready', () => requestAnimationFrame(init), { once: true });
+}
+
 function init() {
   const container = document.body;
   const {scene, camera, renderer, controls, light, labelRenderer} = setupScene(container);
@@ -154,6 +161,3 @@ playBtn.addEventListener('click', () => {
 
 refresh();
 }
-
-// Delay initialization slightly to ensure the React UI is mounted
-requestAnimationFrame(init);

--- a/src/ui.jsx
+++ b/src/ui.jsx
@@ -1,6 +1,9 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 export default function UI() {
+  useEffect(() => {
+    window.dispatchEvent(new Event('ui-ready'));
+  }, []);
   return (
     <div id="ui">
       <img id="logo" src="zodiom.png" alt="Zodiom logo" />


### PR DESCRIPTION
## Summary
- wait for React UI to mount before calling `init`
- signal mount from `UI` component via `ui-ready` event

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6857519ecc2083248f085ae07895b46a