### PR TITLE
Add Pluto support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Zodiom is an in-browser 3D cosmic simulator built with Three.js and Astronomy Bu
 
 ## Features
 
-- Real-time positions for all major planets
+- Real-time positions for all major planets, now including Pluto
 - Travel to any date in history or the future
 - Mystic Mode for a symbolic, sacred look
 - Optional light mode for the UI

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "astronomy-bundle": "^7.7.7",
+        "astronomy-engine": "^2.1.19",
         "express": "^4.19.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -467,6 +468,12 @@
       "version": "7.7.7",
       "resolved": "https://registry.npmjs.org/astronomy-bundle/-/astronomy-bundle-7.7.7.tgz",
       "integrity": "sha512-fCVKeer2EDVYQcLbKWiXWG0gv3TF4PGQNMw9rtNjB3llOkkqQ+w+kQeQ3dIqs6UOPcsoxMR4cvKHdxh5QJPp3w==",
+      "license": "MIT"
+    },
+    "node_modules/astronomy-engine": {
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/astronomy-engine/-/astronomy-engine-2.1.19.tgz",
+      "integrity": "sha512-8yWKNf7UeNbH458h3sAJ6ZgAjE5jTXp/mNNRFoC20j2SHwZIjAQeEsBB2Q3uCFRaTCCJRv33K2XhkhZQMXoX6w==",
       "license": "MIT"
     },
     "node_modules/body-parser": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "type": "module",
   "dependencies": {
     "astronomy-bundle": "^7.7.7",
+    "astronomy-engine": "^2.1.19",
     "express": "^4.19.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/public/textures/pluto.jpg.txt
+++ b/public/textures/pluto.jpg.txt
@@ -1,0 +1,1 @@
+Placeholder texture for pluto

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -18,6 +18,7 @@ import {
 import { createEarth } from "astronomy-bundle/earth";
 import { createMoon } from "astronomy-bundle/moon";
 import {createSun as createSunSolo} from "astronomy-bundle/sun";
+import createPluto from './pluto.js';
 
 const uiRoot = document.getElementById('ui-root');
 if (uiRoot) {
@@ -75,6 +76,7 @@ async function animate() {
     bodies.saturn.astro = createSaturn(toi);
     bodies.uranus.astro = createUranus(toi);
     bodies.neptune.astro = createNeptune(toi);
+    bodies.pluto.astro = createPluto(toi);
     await updatePositions(bodies, toi);
   }
   controls.update();
@@ -95,6 +97,7 @@ async function refresh() {
   bodies.saturn.astro = createSaturn(toi);
   bodies.uranus.astro = createUranus(toi);
   bodies.neptune.astro = createNeptune(toi);
+  bodies.pluto.astro = createPluto(toi);
   await updatePositions(bodies, toi);
 }
 

--- a/src/planets.js
+++ b/src/planets.js
@@ -11,6 +11,7 @@ import {
 } from 'astronomy-bundle/planets';
 import { createEarth } from 'astronomy-bundle/earth';
 import { createMoon } from 'astronomy-bundle/moon';
+import createPluto from './pluto.js';
 
 const SCALE = 5; // scale factor for visualization
 // The planets are intentionally oversized for visibility. Without additional
@@ -64,6 +65,7 @@ export function createPlanetMeshes(toi) {
   const saturn = createSaturn(toi);
   const uranus = createUranus(toi);
   const neptune = createNeptune(toi);
+  const pluto = createPluto(toi);
 
   const sunMesh = new THREE.Mesh(
     new THREE.SphereGeometry(0.5, 64, 64),
@@ -88,6 +90,7 @@ export function createPlanetMeshes(toi) {
   const uranusMesh = createSphereMesh(0.22, 0x66bbff, 'textures/uranus.jpg');
 
   const neptuneMesh = createSphereMesh(0.21, 0x4477ff, 'textures/neptune.jpg');
+  const plutoMesh = createSphereMesh(0.1, 0xbbbbbb, 'textures/pluto.jpg');
 
   const mercuryOrbit = createOrbitLine(0.39 * SCALE);
   const venusOrbit = createOrbitLine(0.72 * SCALE);
@@ -101,6 +104,7 @@ export function createPlanetMeshes(toi) {
   const saturnOrbit = createOrbitLine(9.58 * SCALE);
   const uranusOrbit = createOrbitLine(19.2 * SCALE);
   const neptuneOrbit = createOrbitLine(30.1 * SCALE);
+  const plutoOrbit = createOrbitLine(39.5 * SCALE);
   const asteroidBelt = createAsteroidBelt();
 
   earthMesh.add(moonOrbit);
@@ -119,6 +123,7 @@ export function createPlanetMeshes(toi) {
       saturnMesh,
       uranusMesh,
       neptuneMesh,
+      plutoMesh,
       mercuryOrbit,
       venusOrbit,
       earthOrbit,
@@ -128,6 +133,7 @@ export function createPlanetMeshes(toi) {
       saturnOrbit,
       uranusOrbit,
       neptuneOrbit,
+      plutoOrbit,
       asteroidBelt
     ],
     moonOrbit,
@@ -141,7 +147,8 @@ export function createPlanetMeshes(toi) {
       jupiter: {mesh: jupiterMesh, astro: jupiter},
       saturn: {mesh: saturnMesh, astro: saturn},
       uranus: {mesh: uranusMesh, astro: uranus},
-      neptune: {mesh: neptuneMesh, astro: neptune}
+      neptune: {mesh: neptuneMesh, astro: neptune},
+      pluto: {mesh: plutoMesh, astro: pluto}
     }
   };
 }
@@ -194,4 +201,7 @@ export async function updatePositions(bodies, toi) {
 
   const neptuneCoords = await bodies.neptune.astro.getHeliocentricEclipticRectangularJ2000Coordinates();
   bodies.neptune.mesh.position.set(neptuneCoords.x * SCALE, neptuneCoords.z * SCALE, neptuneCoords.y * SCALE);
+
+  const plutoCoords = await bodies.pluto.astro.getHeliocentricEclipticRectangularJ2000Coordinates();
+  bodies.pluto.mesh.position.set(plutoCoords.x * SCALE, plutoCoords.z * SCALE, plutoCoords.y * SCALE);
 }

--- a/src/pluto.js
+++ b/src/pluto.js
@@ -1,0 +1,12 @@
+import { Body, HelioVector, RotateVector, Rotation_EQJ_ECL } from 'astronomy-engine';
+
+export default function createPluto(toi) {
+  return {
+    async getHeliocentricEclipticRectangularJ2000Coordinates() {
+      const date = toi.getDate ? toi.getDate() : toi;
+      const eq = HelioVector(Body.Pluto, date);
+      const ecl = RotateVector(Rotation_EQJ_ECL(), eq);
+      return { x: ecl.x, y: ecl.y, z: ecl.z };
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- add Astronomy Engine dependency
- add `createPluto` wrapper using Astronomy Engine
- include Pluto mesh and orbit
- refresh bodies for Pluto in animation loops
- add placeholder texture
- document Pluto in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685762138d30832491c0eb02d02ddd94