### PR TITLE
Fix astronomy imports for esbuild

### DIFF
--- a/src/smallBodies.js
+++ b/src/smallBodies.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
-import base from 'astronomia/base.js';
-import { kepler2b, kepler3, trueAnomaly, radius } from 'astronomia/kepler.js';
+import base from 'astronomia/base';
+import { kepler2b, kepler3, trueAnomaly, radius } from 'astronomia/kepler';
 
 const SCALE = 5;
 const RAD = Math.PI / 180;


### PR DESCRIPTION
## Summary
- fix `astronomia` import paths for esbuild bundling

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6858468b1d3c832497d6d6dd96630cee