### PR TITLE
Fix Earth texture visibility

### DIFF
--- a/src/planets.js
+++ b/src/planets.js
@@ -84,7 +84,8 @@ export function createPlanetMeshes(toi) {
 
   const venusMesh = createSphereMesh(0.15, 0xffddaa, 'textures/venus.jpg');
 
-  const earthMesh = createSphereMesh(0.2, 0x3366ff, 'textures/earth.jpg');
+  // Use a white base color so the texture appears unmodified
+  const earthMesh = createSphereMesh(0.2, 0xffffff, 'textures/earth.jpg');
 
   // Slightly higher detail for the moon
   const moonMesh = createSphereMesh(0.05, 0xdddddd, 'textures/moon.jpg', 96);


### PR DESCRIPTION
## Summary
- keep Earth texture colors intact by using a white base material color

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685849d4a0f083249f3e8cf272f12ed3