### PR TITLE
Fix tinted planet textures

### DIFF
--- a/src/planets.js
+++ b/src/planets.js
@@ -35,6 +35,8 @@ function createSphereMesh(radius, color, texturePath, segments = 64, receiveShad
     texturePath,
     tex => {
       material.map = tex;
+      // Remove tint so the texture's true colors show
+      material.color.set(0xffffff);
       material.needsUpdate = true;
     },
     undefined,


### PR DESCRIPTION
## Summary
- correct material color after loading planet textures so textures display without tint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68595b9dd680832488ae50e88eeeb01b