### PR TITLE
Add UI controls and robust time parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ Zodiom is an in-browser 3D cosmic simulator built with Three.js and Astronomy Bu
 - Adjustable timeline speed
 - Reset camera position with one click
 - Expanded starfield backdrop
+- Toggle starfield visibility
+- Jump to the current time with the Now button
 - Physically accurate lighting and smoother camera controls
+- Added Eros asteroid to the small bodies catalog
 - HDR environment map placeholder for an Octane-style look (replace with your own .hdr file)
 
 ## Getting Started

--- a/src/components/UI.jsx
+++ b/src/components/UI.jsx
@@ -40,9 +40,14 @@ export default function UI() {
         <input type="checkbox" id="issToggle" defaultChecked />
       </label>
       <label className="flex items-center justify-between">
+        Show Stars
+        <input type="checkbox" id="starsToggle" defaultChecked />
+      </label>
+      <label className="flex items-center justify-between">
         Speed
         <input type="range" id="speedRange" min="0.1" max="5" step="0.1" defaultValue="1" />
       </label>
+      <button id="now" className="px-2 py-1 bg-white/20 rounded">Now</button>
       <button id="playTimeline" className="px-2 py-1 bg-white/20 rounded">Play Timeline</button>
       <button id="resetCamera" className="px-2 py-1 bg-white/20 rounded">Reset Camera</button>
     </motion.div>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -23,7 +23,7 @@ window.addEventListener('ui-ready', () => requestAnimationFrame(init), { once: t
 
 function init() {
   const container = document.body;
-  const {scene, camera, renderer, controls, light, labelRenderer} = setupScene(container);
+  const {scene, camera, renderer, controls, light, labelRenderer, stars} = setupScene(container);
   let toi = parseDateTime(document.getElementById('datetime').value);
   const clock = new THREE.Clock();
   let playing = false;
@@ -164,6 +164,11 @@ issToggle.addEventListener('change', () => {
   issOrbit.visible = issToggle.checked && orbitToggle.checked;
 });
 
+const starsToggle = document.getElementById('starsToggle');
+starsToggle.addEventListener('change', () => {
+  stars.visible = starsToggle.checked;
+});
+
 const orbitToggle = document.getElementById('orbitToggle');
 orbitToggle.addEventListener('change', () => {
   orbits.forEach(o => o.visible = orbitToggle.checked);
@@ -172,10 +177,18 @@ orbitToggle.addEventListener('change', () => {
 orbits.forEach(o => o.visible = orbitToggle.checked);
 if (!issToggle.checked) issOrbit.visible = false;
 bodies.iss.mesh.visible = issToggle.checked;
+stars.visible = starsToggle.checked;
 
 const speedRange = document.getElementById('speedRange');
 speedRange.addEventListener('input', () => {
   speed = parseFloat(speedRange.value);
+});
+
+const nowBtn = document.getElementById('now');
+nowBtn.addEventListener('click', () => {
+  const now = new Date();
+  document.getElementById('datetime').value = now.toISOString().slice(0,16);
+  refresh();
 });
 
 const resetBtn = document.getElementById('resetCamera');

--- a/src/setupScene.js
+++ b/src/setupScene.js
@@ -85,5 +85,5 @@ export function setupScene(container) {
     labelRenderer.setSize(window.innerWidth, window.innerHeight);
   });
 
-  return {scene, camera, renderer, controls, light, labelRenderer};
+  return {scene, camera, renderer, controls, light, labelRenderer, stars};
 }

--- a/src/smallBodies.js
+++ b/src/smallBodies.js
@@ -58,6 +58,19 @@ export const SMALL_BODIES = [
       epoch: 2459036.5
     },
     color: 0xffaa55
+  },
+  {
+    name: 'Eros',
+    elements: {
+      a: 1.458,
+      e: 0.223,
+      i: 10.830,
+      Omega: 304.4,
+      w: 178.7,
+      M0: 25.0,
+      epoch: 2458849.5
+    },
+    color: 0xa0a0a0
   }
 ];
 

--- a/src/timeUtils.js
+++ b/src/timeUtils.js
@@ -5,6 +5,9 @@ export function parseDateTime(value) {
     return createTimeOfInterest.fromCurrentTime();
   }
   const date = new Date(value);
+  if (isNaN(date)) {
+    return createTimeOfInterest.fromCurrentTime();
+  }
   return createTimeOfInterest.fromDate(date);
 }
 

--- a/test/timeUtils.test.js
+++ b/test/timeUtils.test.js
@@ -20,6 +20,14 @@ describe('parseDateTime', () => {
     assert.ok(nearlyEqual(t, before) || (t > before && t <= after));
   });
 
+  it('returns current time for invalid input', () => {
+    const before = Date.now();
+    const toi = parseDateTime('not-a-date');
+    const after = Date.now();
+    const t = toi.getDate().getTime();
+    assert.ok(nearlyEqual(t, before) || (t > before && t <= after));
+  });
+
   it('advances time by given milliseconds', () => {
     const toi = parseDateTime('2020-01-01T00:00:00Z');
     const advanced = advanceTime(toi, 24 * 60 * 60 * 1000); // plus one day


### PR DESCRIPTION
## Summary
- allow toggling starfield visibility and jumping to current time
- expose the starfield in `setupScene`
- handle invalid dates in `parseDateTime`
- include Eros asteroid
- test invalid date handling

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ca2fc2d0883249591ee54e8cdc8db