### PR TITLE
Add new UI controls and time utility helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ Zodiom is an in-browser 3D cosmic simulator built with Three.js and Astronomy Bu
 - Physically accurate lighting and smoother camera controls
 - Added Eros asteroid to the small bodies catalog
 - HDR environment map placeholder for an Octane-style look (replace with your own .hdr file)
+- Random Date button for surprise exploration
+- Reverse timeline playback
+- Toggle fullscreen mode
+- Wireframe rendering option
+- Reset timeline speed with one click
 
 ## Getting Started
 

--- a/src/components/UI.jsx
+++ b/src/components/UI.jsx
@@ -50,6 +50,14 @@ export default function UI() {
       <button id="now" className="px-2 py-1 bg-white/20 rounded">Now</button>
       <button id="playTimeline" className="px-2 py-1 bg-white/20 rounded">Play Timeline</button>
       <button id="resetCamera" className="px-2 py-1 bg-white/20 rounded">Reset Camera</button>
+      <button id="randomDate" className="px-2 py-1 bg-white/20 rounded">Random Date</button>
+      <button id="reverseTime" className="px-2 py-1 bg-white/20 rounded">Reverse Time</button>
+      <button id="resetSpeed" className="px-2 py-1 bg-white/20 rounded">Reset Speed</button>
+      <button id="fullscreen" className="px-2 py-1 bg-white/20 rounded">Fullscreen</button>
+      <label className="flex items-center justify-between">
+        Wireframe Mode
+        <input type="checkbox" id="wireframeToggle" />
+      </label>
     </motion.div>
   );
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,7 +1,7 @@
 import * as THREE from "three";
 import {setupScene} from './setupScene.js';
 import {CSS2DObject} from 'three/examples/jsm/renderers/CSS2DRenderer.js';
-import {parseDateTime, advanceTime} from './timeUtils.js';
+import {parseDateTime, advanceTime, randomDateTime, formatDateTime} from './timeUtils.js';
 import {createPlanetMeshes, updatePositions} from './planets.js';
 import {createSmallBodyMeshes, updateSmallBodyPositions} from './smallBodies.js';
 import {
@@ -28,6 +28,7 @@ function init() {
   const clock = new THREE.Clock();
   let playing = false;
   let speed = 1;
+  let direction = 1;
 
   let {objects, bodies, moonOrbit, issOrbit} = createPlanetMeshes(toi);
   let smallBodies;
@@ -80,7 +81,7 @@ async function animate() {
   requestAnimationFrame(animate);
   const delta = clock.getDelta();
   if (playing) {
-    toi = advanceTime(toi, delta * 86400000 * speed); // advance with speed factor
+    toi = advanceTime(toi, delta * 86400000 * speed * direction); // advance with speed and direction
     document.getElementById('datetime').value = toi.getDate().toISOString().slice(0,16);
     bodies.sun.astro = createSunSolo(toi);
     bodies.mercury.astro = createMercury(toi);
@@ -196,6 +197,41 @@ resetBtn.addEventListener('click', () => {
   camera.position.set(0, 5, 10);
   controls.target.set(0, 0, 0);
   controls.update();
+});
+
+const randomBtn = document.getElementById('randomDate');
+randomBtn.addEventListener('click', () => {
+  const r = randomDateTime(1950, 2050);
+  document.getElementById('datetime').value = formatDateTime(r).slice(0,16);
+  refresh();
+});
+
+const reverseBtn = document.getElementById('reverseTime');
+reverseBtn.addEventListener('click', () => {
+  direction *= -1;
+  reverseBtn.textContent = direction === 1 ? 'Reverse Time' : 'Forward Time';
+});
+
+const resetSpeedBtn = document.getElementById('resetSpeed');
+resetSpeedBtn.addEventListener('click', () => {
+  speedRange.value = 1;
+  speed = 1;
+});
+
+const fullscreenBtn = document.getElementById('fullscreen');
+fullscreenBtn.addEventListener('click', () => {
+  if (!document.fullscreenElement) {
+    document.body.requestFullscreen();
+  } else {
+    document.exitFullscreen();
+  }
+});
+
+const wireframeToggle = document.getElementById('wireframeToggle');
+wireframeToggle.addEventListener('change', () => {
+  objects.forEach(obj => {
+    if (obj.material) obj.material.wireframe = wireframeToggle.checked;
+  });
 });
 
 const playBtn = document.getElementById('playTimeline');

--- a/src/timeUtils.js
+++ b/src/timeUtils.js
@@ -15,3 +15,14 @@ export function advanceTime(toi, deltaMs) {
   const newDate = new Date(toi.getDate().getTime() + deltaMs);
   return createTimeOfInterest.fromDate(newDate);
 }
+
+export function formatDateTime(toi) {
+  return toi.getDate().toISOString();
+}
+
+export function randomDateTime(startYear = 1950, endYear = 2050) {
+  const start = Date.UTC(startYear, 0, 1);
+  const end = Date.UTC(endYear, 11, 31, 23, 59, 59);
+  const ts = start + Math.random() * (end - start);
+  return createTimeOfInterest.fromDate(new Date(ts));
+}

--- a/test/timeUtils.test.js
+++ b/test/timeUtils.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { parseDateTime, advanceTime } from '../src/timeUtils.js';
+import { parseDateTime, advanceTime, randomDateTime, formatDateTime } from '../src/timeUtils.js';
 
 function nearlyEqual(a, b, tolMs = 1000) {
   return Math.abs(a - b) <= tolMs;
@@ -32,5 +32,18 @@ describe('parseDateTime', () => {
     const toi = parseDateTime('2020-01-01T00:00:00Z');
     const advanced = advanceTime(toi, 24 * 60 * 60 * 1000); // plus one day
     assert.equal(advanced.getDate().toISOString(), '2020-01-02T00:00:00.000Z');
+  });
+});
+
+describe('randomDateTime and formatDateTime', () => {
+  it('generates a date within the given year range', () => {
+    const r = randomDateTime(2000, 2001);
+    const year = r.getDate().getUTCFullYear();
+    assert.ok(year === 2000 || year === 2001);
+  });
+
+  it('formats a TimeOfInterest to ISO string', () => {
+    const toi = parseDateTime('2030-05-06T07:08:09Z');
+    assert.equal(formatDateTime(toi), '2030-05-06T07:08:09.000Z');
   });
 });


### PR DESCRIPTION
## Summary
- add random date, reverse time, reset speed, fullscreen toggle, and wireframe mode controls
- implement helpers `formatDateTime` and `randomDateTime`
- document new features
- test new time utility helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d478386448324aa0c5d71709b3e40