### PR TITLE
Handle invalid date strings

### DIFF
--- a/src/timeUtils.js
+++ b/src/timeUtils.js
@@ -5,8 +5,26 @@ export function parseDateTime(value) {
     return createTimeOfInterest.fromCurrentTime();
   }
   const date = new Date(value);
-  if (isNaN(date)) {
+  // Guard against unparsable or out-of-range dates (e.g. Feb 30)
+  if (Number.isNaN(date.getTime())) {
     return createTimeOfInterest.fromCurrentTime();
+  }
+  const match = value.match(
+    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?(?:Z)?$/
+  );
+  if (match) {
+    const [, y, m, d, hh, mm, ss = '00'] = match;
+    const [year, month, day, hour, minute, second] = [y, m, d, hh, mm, ss].map(Number);
+    if (
+      date.getUTCFullYear() !== year ||
+      date.getUTCMonth() + 1 !== month ||
+      date.getUTCDate() !== day ||
+      date.getUTCHours() !== hour ||
+      date.getUTCMinutes() !== minute ||
+      date.getUTCSeconds() !== second
+    ) {
+      return createTimeOfInterest.fromCurrentTime();
+    }
   }
   return createTimeOfInterest.fromDate(date);
 }

--- a/test/timeUtils.test.js
+++ b/test/timeUtils.test.js
@@ -28,6 +28,14 @@ describe('parseDateTime', () => {
     assert.ok(nearlyEqual(t, before) || (t > before && t <= after));
   });
 
+  it('returns current time for out-of-range dates', () => {
+    const before = Date.now();
+    const toi = parseDateTime('2020-02-30T00:00:00Z');
+    const after = Date.now();
+    const t = toi.getDate().getTime();
+    assert.ok(nearlyEqual(t, before) || (t > before && t <= after));
+  });
+
   it('advances time by given milliseconds', () => {
     const toi = parseDateTime('2020-01-01T00:00:00Z');
     const advanced = advanceTime(toi, 24 * 60 * 60 * 1000); // plus one day


### PR DESCRIPTION
## Summary
- Guard against out-of-range or unparsable date strings in `parseDateTime`
- Add regression test for invalid dates

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c09d7bf0348324822ae5f54e0b12f2